### PR TITLE
xhrOptions param

### DIFF
--- a/bureaucracy.js
+++ b/bureaucracy.js
@@ -27,6 +27,7 @@ function setup (fileinput, options) {
 function create (options) {
   var o = options || {};
   o.formData = o.formData || {};
+  o.xhrOptions = o.xhrOptions || {};
   o.fieldKey = o.fieldKey || 'uploads';
   var bureaucrat = emitter({
     submit: submit
@@ -55,6 +56,9 @@ function create (options) {
       url: o.endpoint || '/api/files',
       body: form
     };
+    Object.keys(o.xhrOptions).forEach(function copyXhrOptions(key) {
+      req.append(key, o.xhrOptions[key]);
+    });
 
     validFiles.forEach(appendFile);
     xhr(req, handleResponse);

--- a/bureaucracy.js
+++ b/bureaucracy.js
@@ -45,7 +45,7 @@ function create (options) {
     bureaucrat.emit('valid', validFiles);
     var form = new FormData();
     Object.keys(o.formData).forEach(function copyFormData(key) {
-      form.append(key, o.formData[key]);
+      form[key] = o.formData[key];
     });
     var req = {
       'Content-Type': 'multipart/form-data',
@@ -57,7 +57,7 @@ function create (options) {
       body: form
     };
     Object.keys(o.xhrOptions).forEach(function copyXhrOptions(key) {
-      req.append(key, o.xhrOptions[key]);
+      req[key] = o.xhrOptions[key];
     });
 
     validFiles.forEach(appendFile);

--- a/readme.markdown
+++ b/readme.markdown
@@ -21,6 +21,7 @@ Option                 | Description
 `endpoint`             | HTTP endpoint to post the files to. Defaults to `/api/files`
 `fieldKey`             | String setting file upload field key. Defaults to `uploads`
 `formData`             | Object containing additional form parameters. Defaults to an empty object: `{}`
+`xhrOptions`           | Object containing options parameters for `xhr` call. Defaults to an empty object: `{}`
 
 There are "common" `validate` functions for your convenience. These can be referenced by name on the `validate` option
 


### PR DESCRIPTION
This allows for `csrf` token attachment for image uploads in `woofmark` following docs at https://www.npmjs.com/package/xhr

Did I miss anything? This, in addition to my previous PRs, is adding some complexity to `bureaucracy` but I do see it as a common use case given its usage in `woofmark`.
